### PR TITLE
6.0.2-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.alipay.sofa</groupId>
     <artifactId>sofa-rpc-boot-projects</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.2-SNAPSHOT</version>
     <packaging>pom</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/sofa-boot-core/pom.xml
+++ b/sofa-boot-core/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-core</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.2-SNAPSHOT</version>
 
     <url>https://github.com/sofastack/sofa-rpc</url>
 

--- a/sofa-boot-plugin/pom.xml
+++ b/sofa-boot-plugin/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-plugin</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.2-SNAPSHOT</version>
 
     <properties>
         <ark.plugin.name>rpc-sofa-boot-plugin</ark.plugin.name>

--- a/sofa-boot-samples/pom.xml
+++ b/sofa-boot-samples/pom.xml
@@ -7,14 +7,14 @@
     <parent>
         <groupId>com.alipay.sofa</groupId>
         <artifactId>sofa-rpc-boot-projects</artifactId>
-        <version>6.0.1-SNAPSHOT</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
 
     <properties>
         <dubbo_version>2.4.10</dubbo_version>
         <cxf.version>3.0.14</cxf.version>
         <sofaboot.version>3.1.4-SNAPSHOT</sofaboot.version>
-        <rpc.starter.version>6.0.1-SNAPSHOT</rpc.starter.version>
+        <rpc.starter.version>6.0.2-SNAPSHOT</rpc.starter.version>
         <curator-test.version>2.9.1</curator-test.version>
         <junit.version>4.12</junit.version>
         <spring-boot-starter-test.version>1.4.2.RELEASE</spring-boot-starter-test.version>

--- a/sofa-boot-starter/pom.xml
+++ b/sofa-boot-starter/pom.xml
@@ -10,7 +10,7 @@
     <modelVersion>4.0.0</modelVersion>
 
     <artifactId>rpc-sofa-boot-starter</artifactId>
-    <version>6.0.1-SNAPSHOT</version>
+    <version>6.0.2-SNAPSHOT</version>
 
     <url>https://github.com/sofastack/sofa-rpc</url>
 
@@ -18,7 +18,7 @@
         <java.version>1.8</java.version>
         <project.build.encoding>UTF-8</project.build.encoding>
         <skipTests>false</skipTests>
-        <rpc.starter.version>6.0.1-SNAPSHOT</rpc.starter.version>
+        <rpc.starter.version>6.0.2-SNAPSHOT</rpc.starter.version>
         <maven-compiler-plugin.version>3.3</maven-compiler-plugin.version>
         <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
         <license-maven-plugin.version>3.0</license-maven-plugin.version>


### PR DESCRIPTION
fix starter version to 6.0.2-SNAPSHOT, because [6.0.1](https://github.com/sofastack/sofa-rpc-boot-projects/releases/tag/v6.0.1) has been released.